### PR TITLE
Handle uninitialized model properties gracefully

### DIFF
--- a/Framework/Core/Model.php
+++ b/Framework/Core/Model.php
@@ -211,7 +211,8 @@ abstract class Model implements \JsonSerializable
         try {
             $data = array_fill_keys(static::getDbColumns(), null);
             foreach ($data as $key => &$item) {
-                $item = $this->{static::toPropertyName($key)};
+                $prop = static::toPropertyName($key);
+                $item = isset($this->{$prop}) ? $this->{$prop} : null;
             }
             // Insert new record
             if ($this->_dbId === null) {
@@ -303,13 +304,15 @@ abstract class Model implements \JsonSerializable
             throw new Exception("Parameter modelClass must be a subclass of " . self::class);
         }
         $refColumn ??= static::getConventions()->getFkColumn($modelClass);
+        $ownerProp = self::toPropertyName($refColumn);
+        $ownerVal = isset($this->{$ownerProp}) ? $this->{$ownerProp} : null;
         return $this->_resultSet->getOneRelated(
             $modelClass,
             self::toPropertyName($refColumn),
-            fn($e) => $e->{self::toPropertyName($refColumn)},
+            fn($e) => (isset($e->{self::toPropertyName($refColumn)}) ? $e->{self::toPropertyName($refColumn)} : null),
             fn($e) => $e->getIdValue(),
             $modelClass::getPkColumnName(),
-            $this->{self::toPropertyName($refColumn)},
+            $ownerVal,
         );
     }
 
@@ -337,7 +340,7 @@ abstract class Model implements \JsonSerializable
             $where,
             $whereParams,
             fn($e) => $e->getIdValue(),
-            fn($e) => $e->{self::toPropertyName($refColumn)},
+            fn($e) => (isset($e->{self::toPropertyName($refColumn)}) ? $e->{self::toPropertyName($refColumn)} : null),
             $this->getIdValue()
         );
     }
@@ -388,7 +391,8 @@ abstract class Model implements \JsonSerializable
     private function getIdValue(): mixed
     {
         $pk = static::getPkColumnName();
-        return $this->{static::toPropertyName($pk)};
+        $prop = static::toPropertyName($pk);
+        return isset($this->{$prop}) ? $this->{$prop} : null;
     }
 
     /**


### PR DESCRIPTION
Malo by vyriešiť to, že je potrebné inicializovať všetky property modelu, aj tie, ktoré majú byť null